### PR TITLE
feat(commands): Change option to specify test keyword

### DIFF
--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -13,6 +13,8 @@ const { LOG_LEVELS, setLogLevel, log } = require('../utils/logger');
 const { loadConfig } = require('../config/configLoader');
 const { processFile } = require('../core/fileProcessor');
 const { startWatcher } = require('../core/watcher');
+const { Option } = require('commander');
+
 
 /**
  * Logs the effective configuration and any command-line overrides.
@@ -189,11 +191,11 @@ module.exports = (program) => {
       '-n, --dry-run',
       'perform a dry run: simulate file generation without writing to disk', // Changed to lowercase
     )
-    .option(
+    .addOption(new Option(
       '-k, --test-keyword <keyword>',
-      'specify keyword for test blocks (it or test)', // Changed to lowercase
-      'it',
-    )
+      'specify keyword for test blocks', // Changed to lowercase
+      // 'it',
+    ).choices(['it', 'test']))
     .option(
       '--no-cleanup',
       'do not delete generated .test.js files when source yaml is unlinked in watch mode', // Changed to lowercase


### PR DESCRIPTION
This commit changes an existing option `--test-keyword` to the `generate` command. This allows users to specify which keyword they want to use for test blocks within the generated `.test.js` files. The default is not specified, allowing the config file to specify the default instead.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made? 

Add an option to specify the keyword for test blocks through the command-line interface using the Commander library's `Option` API.

### Why are these changes being made?

This change is being implemented to provide developers with the flexibility to specify their preferred keyword for test blocks, either 'it' or 'test', directly from the command line, aligning with diverse testing preferences and practices. The use of Commander’s new API enhances configurability and code clarity.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->