### PR TITLE
Chore/fix-generate-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,9 +100,9 @@
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
+    "doctoc": "^2.2.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
-    "doctoc": "^2.2.1",
     "eslint-plugin-jsdoc": "^48.2.3",
     "eslint-plugin-markdown": "^3.0.1",
     "jest": "^30.0.5",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "src",
     "config/default.json",
     "LICENSE",
+    "config/default-config.schema.json",
     "README.md"
   ],
   "scripts": {


### PR DESCRIPTION
The `default-config.schema.json` file was missing from the published package. This change adds it to the `files` array in `package.json` to ensure it's included in future releases. This allows users to properly validate their configurations against the schema.